### PR TITLE
Add vedika-sdk to Third-party Web APIs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2939,3 +2939,7 @@ projects:
     category: others
     pypi_id: structlog
     
+  - name: vedika-sdk
+    github_id: vedika-io/vedika-sdk-python
+    category: third-party-apis
+    pypi_id: vedika-sdk


### PR DESCRIPTION
Adding **vedika-sdk** - Python SDK for Vedika Astrology API.

**Category:** Third-party Web APIs

**What is it?**
- Official Python SDK for Vedika AI-powered Vedic astrology API
- Supports natural language queries for astrology insights
- 108+ endpoints for birth charts, horoscopes, compatibility, etc.
- 22 language support

**Links:**
- GitHub: https://github.com/vedika-io/vedika-sdk-python
- PyPI: https://pypi.org/project/vedika-sdk/
- Docs: https://vedika.io/docs