### PR TITLE
Add iploop-sdk to Web Scraping & Crawling

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2939,3 +2939,8 @@ projects:
     category: others
     pypi_id: structlog
     
+  - name: iploop-sdk
+    github_id: Iploop/proxyclaw
+    category: web-scraping
+    pypi_id: iploop-sdk
+    description: "Residential proxy SDK with 66 site presets and built-in anti-detection (TLS fingerprinting, Chrome headers). 2M+ IPs, 195+ countries."


### PR DESCRIPTION
Adds `iploop-sdk` ([PyPI](https://pypi.org/project/iploop-sdk/)) to the Web Scraping & Crawling category.

**iploop-sdk** is a residential proxy SDK with:
- 66 built-in site presets (Amazon, Google, Reddit, etc.)
- Anti-detection: TLS/JA3 fingerprinting + Chrome header injection
- 2M+ residential IPs across 195+ countries
- Auto-retry with IP rotation

GitHub: [Iploop/proxyclaw](https://github.com/Iploop/proxyclaw)