### PR TITLE
Add Human Browser (cloud Python-friendly browser MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This curated list contains 590 awesome open-source projects with a total of 3.5M
 - [Servers](#servers) _12 projects_
 - [Authorization & Authentication](#authorization--authentication) _39 projects_
 - [HTML Processing](#html-processing) _10 projects_
+- [Human Browser](https://github.com/VirixLabs/humanbrowser) - Cloud-hosted residential browser MCP for AI agents. Real residential IP per session, automated captcha solving (reCAPTCHA, hCaptcha, Turnstile, PerimeterX), live viewer URL for human-in-the-loop, MCP + A2A endpoints, $1 free trial.
 - [URL Utilities](#url-utilities) _6 projects_
 - [OpenAPI Utilities](#openapi-utilities) _23 projects_
 - [GraphQL Utilities](#graphql-utilities) _16 projects_


### PR DESCRIPTION
## What

Add [Human Browser](https://github.com/VirixLabs/humanbrowser) to the list.

## Why this fits

Human Browser is a cloud-hosted residential browser exposed as an MCP server, designed specifically for AI agents that need to access the real web (logins, captcha-walls, anti-bot stacks).

- **Hosted MCP endpoint** at `agent.humanbrowser.cloud/mcp` (Streamable HTTP, Bearer token).
- **Real residential IP per session** (geo-selectable, not a datacenter Chrome).
- **Automated captcha solving** (reCAPTCHA v2/v3, hCaptcha, Turnstile, PerimeterX).
- **Live viewer URL** with every task for human-in-the-loop takeover (CAPTCHA, 2FA, OTP).
- **Sticky profile/cookies** across sessions (logins persist).
- **Pay-as-you-go** pricing, no subscription, $1 free trial.
- Open-source skill on npm: `@virixlabs/humanbrowser` (Apache-2.0).

Happy to adjust placement/format. Thanks for maintaining the list!