### PR TITLE
Add invisible_playwright (web-scraping)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1411,6 +1411,10 @@ projects:
     category: web-frameworks
     conda_id: conda-forge/web.py
     pypi_id: web.py
+  - name: invisible_playwright
+    github_id: feder-cr/invisible_playwright
+    category: web-scraping
+    labels: ["playwright"]
   - name: flask-mongorest
     github_id: closeio/flask-mongorest
     category: web-frameworks


### PR DESCRIPTION
adds invisible_playwright to the web-scraping category in projects.yaml. it's a python playwright wrapper over a patched firefox with a realistic, consistent fingerprint, for scraping pages that filter automated browsers (~1.5k stars, above the min). not on pypi so just github_id. opened as draft, happy to adjust.