### PR TITLE
Add docpull to web scraping tools

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2944,3 +2944,7 @@ projects:
     category: web-scraping
     pypi_id: iploop-sdk
     description: "Residential proxy SDK with 66 site presets and built-in anti-detection (TLS fingerprinting, Chrome headers). 2M+ IPs, 195+ countries."
+  - name: docpull
+    github_id: raintree-technology/docpull
+    pypi_id: docpull
+    category: web-scraping


### PR DESCRIPTION
Adds DocPull to the web scraping and crawling category. DocPull is a Python package for extracting public static/server-rendered web sources into clean Markdown, NDJSON, SQLite, and reproducible local packs. It is published on PyPI and has 17k+ downloads.
