### PR TITLE
Add indexgap

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2944,3 +2944,8 @@ projects:
     category: web-scraping
     pypi_id: iploop-sdk
     description: "Residential proxy SDK with 66 site presets and built-in anti-detection (TLS fingerprinting, Chrome headers). 2M+ IPs, 195+ countries."
+  - name: indexgap
+    github_id: borisowlexa2010-star/IndexGap
+    pypi_id: indexgap
+    category: testing
+    description: "Audits generated web pages — invented facts, template-wide breakage, near-duplicates, hreflang. Zero dependencies."


### PR DESCRIPTION
indexgap audits generated web pages: it fact-checks the numbers printed on each page against the dataset row that produced it, collapses findings that are really one template defect into a single work order, clusters near-duplicates, and validates hreflang clusters across language versions.

Fits alongside the other web-testing tools here — it is a QA step for generated HTML rather than a generator.

Python 3.9–3.13, standard library only, zero dependencies. On PyPI as `indexgap`. MIT.
Docs covering all 58 checks: https://borisowlexa2010-star.github.io/IndexGap/